### PR TITLE
Provide a default service

### DIFF
--- a/Locksmith/Locksmith.swift
+++ b/Locksmith/Locksmith.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 public let LocksmithErrorDomain = "com.locksmith.error"
+public let LocksmithDefaultService = NSBundle.mainBundle().infoDictionary![kCFBundleIdentifierKey] as String
 
 public class Locksmith: NSObject {
     // MARK: Perform request
@@ -222,15 +223,23 @@ public class Locksmith: NSObject {
 
 // MARK: Convenient Class Methods
 extension Locksmith {
-    public class func saveData(data: Dictionary<String, String>, inService service: String, forUserAccount userAccount: String) -> NSError? {
+    public class func saveData(data: Dictionary<String, String>, inService service: String = LocksmithDefaultService, forUserAccount userAccount: String) -> NSError? {
         let saveRequest = LocksmithRequest(service: service, userAccount: userAccount, requestType: .Create, data: data)
         let (dictionary, error) = Locksmith.performRequest(saveRequest)
         return error
     }
     
+    public class func loadData(#userAccount: String) -> (NSDictionary?, NSError?) {
+        return loadDataInService(LocksmithDefaultService, forUserAccount: userAccount)
+    }
+    
     public class func loadDataInService(service: String, forUserAccount userAccount: String) -> (NSDictionary?, NSError?) {
         let readRequest = LocksmithRequest(service: service, userAccount: userAccount)
         return Locksmith.performRequest(readRequest)
+    }
+    
+    public class func deleteData(#userAccount: String) -> NSError? {
+        return deleteDataInService(LocksmithDefaultService, forUserAccount: userAccount)
     }
     
     public class func deleteDataInService(service: String, forUserAccount userAccount: String) -> NSError? {
@@ -239,7 +248,7 @@ extension Locksmith {
         return error
     }
     
-    public class func updateData(data: Dictionary<String, String>, inService service: String, forUserAccount userAccount: String) -> NSError? {
+    public class func updateData(data: Dictionary<String, String>, inService service: String = LocksmithDefaultService, forUserAccount userAccount: String) -> NSError? {
         let updateRequest = LocksmithRequest(service: service, userAccount: userAccount, requestType: .Update, data: data)
         let (dictionary, error) = Locksmith.performRequest(updateRequest)
         return error

--- a/Locksmith/LocksmithRequest.swift
+++ b/Locksmith/LocksmithRequest.swift
@@ -23,7 +23,7 @@ public enum RequestType: Int {
 public class LocksmithRequest: NSObject, DebugPrintable {
     // Keychain Options
     // Required
-    var service: String
+    var service = NSBundle.mainBundle().infoDictionary![kCFBundleIdentifierKey] as String
     var userAccount: String
     var type: RequestType = .Read  // Default to non-destructive
     
@@ -39,17 +39,17 @@ public class LocksmithRequest: NSObject, DebugPrintable {
         return "service: \(self.service), type: \(self.type.rawValue), userAccount: \(self.userAccount)"
     }
     
-    required public init(service: String, userAccount: String) {
+    required public init(service: String = LocksmithDefaultService, userAccount: String) {
         self.service = service
         self.userAccount = userAccount
     }
     
-    convenience init(service: String, userAccount: String, requestType: RequestType) {
+    convenience init(service: String = LocksmithDefaultService, userAccount: String, requestType: RequestType) {
         self.init(service: service, userAccount: userAccount)
         self.type = requestType
     }
     
-    convenience init(service: String, userAccount: String, requestType: RequestType, data: NSDictionary) {
+    convenience init(service: String = LocksmithDefaultService, userAccount: String, requestType: RequestType, data: NSDictionary) {
         self.init(service: service, userAccount: userAccount, requestType: requestType)
         self.data = data
     }

--- a/README.md
+++ b/README.md
@@ -20,14 +20,27 @@ it, simply add the following line to your Podfile:
 **Save Data**
 
 ```swift
-Locksmith.saveData(["some key": "some value"], inService: "myService", forUserAccount: "myUserAccount")
+Locksmith.saveData(["some key": "some value"], forUserAccount: "myUserAccount")
 ```
 
 **Load Data**
 
 ```swift
+let (dictionary, error) = Locksmith.loadData(forUserAccount: "myUserAccount")
+```
+
+**Load Data, Specifying a Service**
+
+```swift
 let (dictionary, error) = Locksmith.loadData(inService: "myService", forUserAccount: "myUserAccount")
 ```
+
+**Save Data, Specifying a Service**
+
+```swift
+Locksmith.saveData(["some key": "some value"], inService: "myService", forUserAccount: "myUserAccount")
+```
+
 
 **Update Data**
 


### PR DESCRIPTION
`service` (which maps to `kSecAttrService`) isn't relevant to many developers, who store only one username/password pair, for example.

I propose giving `service` a default value of the bundle identifier when unspecified:

    var service = NSBundle.mainBundle().infoDictionary![kCFBundleIdentifierKey] as String

This would make the interface to Locksmith even cleaner.

A few caveats, so don't merge it in right away:

- The project won't build (`info.plist` is missing)
- I haven't tested this out yet
- There seem to be two copies of `Locksmith.swift` and `LocksmithRequest.swift` (one pair in `Locksmith/` and one in `Pod/Classes/`)

Just opening this PR for initial code review and thoughts.