### PR TITLE
Keychain enumeration

### DIFF
--- a/Pod/Classes/Locksmith.swift
+++ b/Pod/Classes/Locksmith.swift
@@ -316,7 +316,7 @@ extension Locksmith {
         return NSError(domain: LocksmithErrorDomain, code: code, userInfo: ["message": message])
     }
     
-    public class func each(userAccount: String, itemHandler : NSDictionary -> ()) {
+    public class func each(userAccount: String?, itemHandler : NSDictionary -> ()) {
         for securityClass in SecurityClass.allClasses {
             let request = LocksmithRequest(userAccount: userAccount)
             request.type = .Read

--- a/Pod/Classes/Locksmith.swift
+++ b/Pod/Classes/Locksmith.swift
@@ -315,6 +315,21 @@ extension Locksmith {
         let message = internalErrorMessage(forCode: code)
         return NSError(domain: LocksmithErrorDomain, code: code, userInfo: ["message": message])
     }
+    
+    public class func each(userAccount: String, itemHandler : NSDictionary -> ()) {
+        for securityClass in SecurityClass.allClasses {
+            let request = LocksmithRequest(userAccount: userAccount)
+            request.type = .Read
+            request.securityClass = securityClass
+            request.matchLimit = .Many
+            
+            let (result, error) = Locksmith.performRequest(request)
+            
+            if let result = result {
+                itemHandler(result)
+            }
+        }
+    }
 }
 
 // MARK: Dictionary Extensions

--- a/Pod/Classes/Locksmith.swift
+++ b/Pod/Classes/Locksmith.swift
@@ -169,7 +169,7 @@ public class Locksmith: NSObject {
         switch request.matchLimit {
         case .One:
             dictionary.setObject(kSecMatchLimitOne, forKey: String(kSecMatchLimit))
-        case .Many:
+        case .Many, .All:
             dictionary.setObject(kSecMatchLimitAll, forKey: String(kSecMatchLimit))
         }
         
@@ -321,7 +321,7 @@ extension Locksmith {
             let request = LocksmithRequest(userAccount: userAccount)
             request.type = .Read
             request.securityClass = securityClass
-            request.matchLimit = .Many
+            request.matchLimit = .All
             
             let (result, error) = Locksmith.performRequest(request)
             

--- a/Pod/Classes/LocksmithRequest.swift
+++ b/Pod/Classes/LocksmithRequest.swift
@@ -10,6 +10,8 @@ import Security
 
 public enum SecurityClass: Int {
     case GenericPassword, InternetPassword, Certificate, Key, Identity
+    
+    static let allClasses = [GenericPassword, InternetPassword, Certificate, Key, Identity]
 }
 
 public enum MatchLimit: Int {

--- a/Pod/Classes/LocksmithRequest.swift
+++ b/Pod/Classes/LocksmithRequest.swift
@@ -32,7 +32,7 @@ public class LocksmithRequest: NSObject, DebugPrintable {
     // Keychain Options
     // Required
     public var service: String = LocksmithDefaultService
-    public var userAccount: String
+    public var userAccount: String?
     public var type: RequestType = .Read  // Default to non-destructive
     
     // Optional
@@ -45,20 +45,21 @@ public class LocksmithRequest: NSObject, DebugPrintable {
     
     // Debugging
     override public var debugDescription: String {
-        return "service: \(self.service), type: \(self.type.rawValue), userAccount: \(self.userAccount)"
+        let accountString = self.userAccount ?? "<nil>"
+        return "service: \(self.service), type: \(self.type.rawValue), userAccount: \(accountString)"
     }
     
-    required public init(userAccount: String, service: String = LocksmithDefaultService) {
+    required public init(userAccount: String?, service: String = LocksmithDefaultService) {
         self.service = service
         self.userAccount = userAccount
     }
     
-    public convenience init(userAccount: String, requestType: RequestType, service: String = LocksmithDefaultService) {
+    public convenience init(userAccount: String?, requestType: RequestType, service: String = LocksmithDefaultService) {
         self.init(userAccount: userAccount, service: service)
         self.type = requestType
     }
     
-    public convenience init(userAccount: String, requestType: RequestType, data: NSDictionary, service: String = LocksmithDefaultService) {
+    public convenience init(userAccount: String?, requestType: RequestType, data: NSDictionary, service: String = LocksmithDefaultService) {
         self.init(userAccount: userAccount, requestType: requestType, service: service)
         self.data = data
     }

--- a/Pod/Classes/LocksmithRequest.swift
+++ b/Pod/Classes/LocksmithRequest.swift
@@ -15,7 +15,8 @@ public enum SecurityClass: Int {
 }
 
 public enum MatchLimit: Int {
-    case One, Many
+    case One, All
+    @availability(*, deprecated=1.1.2, message="Use .All instead.") case Many
 }
 
 public enum RequestType: Int {

--- a/Pod/Info.plist
+++ b/Pod/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### Unfinished — Do Not Merge

This PR addresses https://github.com/matthewpalmer/Locksmith/issues/45.

This code…

- Adds a static array of security classes
- Implements `each(userAccount:, itemHandler)` by iterating through the classes and calling the handler when appropriate
- Deprecates `.Many` and replaces it with `.All`
- Makes `userAccount` optional

This enables two types of iteration possible. One with a user account:

    Locksmith.each("foo@bar.com") { result in
        print(result)
    }
    
And one without:

    Locksmith.each() { result in
        print(result)
    }

`SecItemCopyMatching` will return an array, not a dictionary, if `kSecMatchLimit != 1`. But `performRequest(_:)` only handles a single dictionary return value at the moment. So I think that will need to be updated as well.

Still to do:

- Test on an app with real-world data
- Handle arrays in `performRequest(_:)`

Bonus points:

- In the Swift 2.0 branch, use `SequenceType` and `CollectionType` protocols to make an enumerable type. This would enable developers to filter results, get counts, iterate in reverse, etc.

@matthewpalmer I'm adding you as a collaborator on my fork so you can push directly to this branch if you want. Anyone else interested, let me know.