### PR TITLE
Add support for tvOS

### DIFF
--- a/Locksmith.podspec
+++ b/Locksmith.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
 
   s.requires_arc = true
 


### PR DESCRIPTION
This patch adds support to the pod to be used on a tvOS app project.

I have a development kit and have verified it working on my AppleTV app.