### PR TITLE
Remove print statements

### DIFF
--- a/Source/Locksmith.swift
+++ b/Source/Locksmith.swift
@@ -480,7 +480,6 @@ public extension ReadableSecureStorable where Self : GenericPasswordSecureStorab
                 return nil
             }
         } catch {
-            print(error)
             return nil
         }
     }
@@ -495,7 +494,6 @@ public extension ReadableSecureStorable where Self : InternetPasswordSecureStora
                 return nil
             }
         } catch {
-            print(error)
             return nil
         }
     }

--- a/Source/LocksmithSecurityClass.swift
+++ b/Source/LocksmithSecurityClass.swift
@@ -18,7 +18,6 @@ public enum LocksmithSecurityClass: RawRepresentable {
         case String(kSecClassIdentity):
             self = Identity
         default:
-            print("SecurityClass: Invalid raw value provided. Defaulting to .GenericPassword")
             self = GenericPassword
         }
     }


### PR DESCRIPTION
Print statements in the library are not very helpful, and you can always add them to your code according to your needs. So I suggest to drop them. 