### PR TITLE
Cannot update an existing record in the keychain

### DIFF
--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		0EC25C9A1BA38660004191AF /* LocksmithInternetProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC25C461BA38539004191AF /* LocksmithInternetProtocol.swift */; };
 		0EC25C9B1BA38662004191AF /* LocksmithSecurityClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC25C471BA38539004191AF /* LocksmithSecurityClass.swift */; };
 		0EC25C9C1BA38663004191AF /* LocksmithSecurityClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC25C471BA38539004191AF /* LocksmithSecurityClass.swift */; };
+		222E80731C59906A00830FB3 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E80721C59906A00830FB3 /* User.swift */; };
+		222E80741C59906A00830FB3 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E80721C59906A00830FB3 /* User.swift */; };
 		DF6BD4B91BB0524500A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF6BD4BC1BB054CB00A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF6BD4BD1BB054D400A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -78,6 +80,7 @@
 		0EC25C9D1BA389BD004191AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0EC25C9E1BA389CB004191AF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0EC25CA71BA39C9F004191AF /* Locksmith.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Locksmith.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		222E80721C59906A00830FB3 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Locksmith.h; sourceTree = "<group>"; };
 		FBD0C9491C1866BE00291F2A /* Locksmith.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Locksmith.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -141,6 +144,7 @@
 				0EC25C451BA38539004191AF /* LocksmithInternetAuthenticationType.swift */,
 				0EC25C461BA38539004191AF /* LocksmithInternetProtocol.swift */,
 				0EC25C471BA38539004191AF /* LocksmithSecurityClass.swift */,
+				222E80721C59906A00830FB3 /* User.swift */,
 				0EC25CA01BA38A05004191AF /* Supporting Files */,
 			);
 			path = Source;
@@ -445,6 +449,7 @@
 				0EC25C9B1BA38662004191AF /* LocksmithSecurityClass.swift in Sources */,
 				0EC25C911BA3864F004191AF /* Locksmith.swift in Sources */,
 				0EC25C8F1BA3864C004191AF /* Dictionary_Initializers.swift in Sources */,
+				222E80731C59906A00830FB3 /* User.swift in Sources */,
 				0EC25C951BA38657004191AF /* LocksmithError.swift in Sources */,
 				0EC25C971BA3865B004191AF /* LocksmithInternetAuthenticationType.swift in Sources */,
 				0EC25C991BA3865F004191AF /* LocksmithInternetProtocol.swift in Sources */,
@@ -455,6 +460,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				222E80741C59906A00830FB3 /* User.swift in Sources */,
 				0EC25C8E1BA38649004191AF /* LocksmithTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/User.swift
+++ b/Source/User.swift
@@ -1,0 +1,55 @@
+//
+//  User.swift
+//
+//  Created by Sam Kington on 27/01/2016.
+//  Copyright © 2016 \(work). All rights reserved.
+//
+
+class User: ReadableSecureStorable,
+            CreateableSecureStorable,
+            DeleteableSecureStorable,
+            GenericPasswordSecureStorable
+{
+    // MARK: Properties
+    var username: String?
+    var password: String?
+
+    // Locksmith protocol properties
+    let service = "Work thing"
+    let account = "Default work thing login details"
+    var data: [String: AnyObject] {
+        get {
+            return ["username": username!, "password": password!]
+        }
+        set(keychainData) {
+            self.username = keychainData["username"] as? String
+            self.password = keychainData["password"] as? String
+        }
+    }
+
+    // MARK: Initialiser
+    init() { }
+    init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+
+    func fetch() -> User? {
+        guard let result = self.readFromSecureStore() else { return nil }
+        let newUser = User()
+        newUser.data = result.data!
+        return newUser
+    }
+    
+    func store() -> Bool {
+        do { try self.createInSecureStore() }
+        catch let error { print("Couldn't store: \(error)"); return false }
+        return true
+    }
+    
+    func delete() -> Bool {
+        do { try self.deleteFromSecureStore() }
+        catch let error { print("Couldn't delete: \(error)"); return false }
+        return true
+    }
+}

--- a/Source/User.swift
+++ b/Source/User.swift
@@ -5,6 +5,8 @@
 //  Copyright © 2016 \(work). All rights reserved.
 //
 
+import Locksmith
+
 class User: ReadableSecureStorable,
             CreateableSecureStorable,
             DeleteableSecureStorable,

--- a/Tests/LocksmithTests.swift
+++ b/Tests/LocksmithTests.swift
@@ -438,6 +438,14 @@ class LocksmithTests: XCTestCase {
         let secondUser = User(username: "second user", password: "123456 like my luggage")
         XCTAssertTrue(secondUser.store(), "We can create a second user")
         
+        // We can update it and its username changes.
+        secondUser.username = "second user with a haircut"
+        XCTAssertTrue(secondUser.store(), "We can store a second user again")
+        let refetchedSecondUser = User().fetch()
+        XCTAssertNotNil(refetchedSecondUser, "We can fetch the second user again")
+        XCTAssertEqual(refetchedSecondUser!.username!, secondUser.username, "Its details have updated")
+        
+        
         // We can create a third user, which replaces the second user.
         let thirdUser = User(username: "third user", password: "Take a wild guess")
         XCTAssertTrue(thirdUser.store(), "We can create a third user")

--- a/Tests/LocksmithTests.swift
+++ b/Tests/LocksmithTests.swift
@@ -412,4 +412,41 @@ class LocksmithTests: XCTestCase {
 
         waitForExpectationsWithTimeout(0.1, handler: nil)
     }
+
+    func testStorage() {
+        // We start off with an empty user.
+        let notFoundUser = User().fetch()
+        XCTAssertNil(notFoundUser, "Nothing to fetch at first")
+        
+        // We can store a user.
+        let newUser = User()
+        newUser.username = "sample user"
+        newUser.password = "damnsecure"
+        XCTAssertTrue(newUser.store(), "We stored a user")
+        
+        // We can now fetch it again.
+        let fetchedUser = User().fetch()
+        XCTAssertNotNil(fetchedUser, "We can fetch something now")
+        XCTAssertEqual(fetchedUser!.username!, newUser.username, "Same username as we just stored")
+        
+        // We can delete it.
+        XCTAssertTrue(newUser.delete(), "We can delete the user we first created")
+        let fetchedAgainUser = User().fetch()
+        XCTAssertNil(fetchedAgainUser, "We can no longer fetch the user")
+        
+        // We can create a new user.
+        let secondUser = User(username: "second user", password: "123456 like my luggage")
+        XCTAssertTrue(secondUser.store(), "We can create a second user")
+        
+        // We can create a third user, which replaces the second user.
+        let thirdUser = User(username: "third user", password: "Take a wild guess")
+        XCTAssertTrue(thirdUser.store(), "We can create a third user")
+        let hopefullyThirdFetchedUser = User().fetch()
+        XCTAssertNotNil(hopefullyThirdFetchedUser, "We can fetch a user")
+        XCTAssertEqual(hopefullyThirdFetchedUser!.username!, thirdUser.username, "It has the third user's details")
+        
+        // Delete it for tidiness
+        secondUser.delete()
+    }
+
 }


### PR DESCRIPTION
This isn't actually a pull request, as (a) there's a lot of code duplication in the tests, and (b) the tests currently fail! But it was the easiest way that occurred to me of bundling up the code I have currently that's failing.

It naïvely appears to be a recurrence of [the very first issue in this project](https://github.com/matthewpalmer/Locksmith/issues/1), but I have absolutely no experience in debugging Swift so I couldn't say.

For a Secret Work Project, we need an app that logs into our web service, and we need to remember those login details. So GenericPasswordSecureStorable looked like the easiest way of implementing this, albeit with a constant `account` value as we'd only ever store one set of user details.

As you'll hopefully see when running the tests, the C, R and D part of CRUD work fine; but when I try to update the details, I get an exception. And I get that whether I update the original object or I try to store a new one (which is good - if it had varied between which object was trying to store stuff that would have been the stuff of nightmares).

I'm new to Swift (normally I'm a Perl programmer), so some of the code might be unidiomatic, and hopefully the fix is to say "why on Earth are you doing *that*‽", update the documentation, and tell me not to be such a fool. But in case it actually is an issue in the guts of something horrible, you have a test method to run now.