### PR TITLE
Remove the NoError case from LocksmithError enum.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ public enum LocksmithError: ErrorType {
   case Decode
   case Duplicate
   case InteractionNotAllowed
-  case NoError
   case NotAvailable
   case NotFound
   case Param

--- a/Source/LocksmithError.swift
+++ b/Source/LocksmithError.swift
@@ -7,7 +7,6 @@ public enum LocksmithError: String, ErrorType {
     case Decode = "Unable to decode the provided data."
     case Duplicate = "The item already exists."
     case InteractionNotAllowed = "Interaction with the Security Server is not allowed."
-    case NoError = "No error."
     case NotAvailable = "No trust results are available."
     case NotFound = "The item cannot be found."
     case Param = "One or more parameters passed to the function were not valid."


### PR DESCRIPTION
Looking at the return codes in Apple's documentation (https://developer.apple.com/library/ios/documentation/Security/Reference/keychainservices/#//apple_ref/c/econst/errSecSuccess). A return code of 0 means success (similar to zero exit code in Unix).

I can't imagine a case where you would want to throw a LocksmithError where the ErrorType is NoError. That doesn't make sense to me :-)

There are some other LocksmithError cases that aren't being used at all. Perhaps we should remove these? 
