### PR TITLE
Build only active architectures

### DIFF
--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Mathew Palmer";
 				TargetAttributes = {
 					0EC25C581BA385AA004191AF = {
@@ -753,6 +753,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
https://github.com/matthewpalmer/Locksmith/commit/e002690ccf06431a63b1583fb8917c296245bdae

This commit should not be necessary. Any linking errors can be resolved by making locksmith a target dependency.
