### PR TITLE
Fix warning when linking against Locksmith from an app extension

### DIFF
--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -766,6 +767,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Unless a framework has been built with the flag `APPLICATION_EXTENSION_API_ONLY`, Xcode emits a warning when linking against that framework from an app extension target:
> linking against dylib not safe for use in application extensions

By adding the `APPLICATION_EXTENSION_API_ONLY` flag to Locksmith's build configs, we're asking the compiler to verify at framework compile time that the framework does not touch APIs that are unavailable to app extensions, such as `UIApplication.sharedApplication`.

I tested this change by building each of the framework targets.