### PR TITLE
Swift 3.0 and Xcode 8 GM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,23 @@ env:
   - LANG=en_US.UTF-8
   matrix:
     - DESTINATION="OS=3.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator3.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="YES"
-    - DESTINATION="OS=2.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator2.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=2.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator3.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
     - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.12 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.11 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
     # "build_example" should be YES but travis was giving me grief
     - DESTINATION="OS=10.0,name=iPad Air 2" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="OS=10.0,name=iPhone 7" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="OS=10.0,name=iPhone 7 Plus" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
-    - DESTINATION="OS=9.0,name=iPad 2" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 6" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 6 Plus" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.0,name=iPad 2" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.0,name=iPhone 6" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.0,name=iPhone 6 Plus" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
-    - DESTINATION="OS=8.1,name=iPad 2" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=8.2,name=iPhone 4S" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=8.3,name=iPhone 5" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=8.4,name=iPhone 5S" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=8.1,name=iPad 2" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=8.2,name=iPhone 4S" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=8.3,name=iPhone 5" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=8.4,name=iPhone 5S" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
 before_install:
   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - LANG=en_US.UTF-8
   matrix:
     - DESTINATION="OS=3.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator3.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="YES"
-    - DESTINATION="OS=2.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator2.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="YES"
+    - DESTINATION="OS=2.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator2.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
     - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.12 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.11 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 # Taken from https://github.com/Alamofire/AlamofireImage
 language: objective-c
-osx_image: xcode7
+osx_image: xcode8
 env:
   global:
   - LC_CTYPE=en_US.UTF-8
   - LANG=en_US.UTF-8
   matrix:
+    - DESTINATION="OS=3.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator3.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="YES"
     - DESTINATION="OS=2.0,name=Apple Watch - 42mm" SCHEME="Locksmith watchOS" SDK=watchsimulator2.0 RUN_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="YES"
+
+    - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.12 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="arch=x86_64" SCHEME="Locksmith OS X" SDK=macosx10.11 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
 
     # "build_example" should be YES but travis was giving me grief
+    - DESTINATION="OS=10.0,name=iPad Air 2" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=10.0,name=iPhone 7" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=10.0,name=iPhone 7 Plus" SCHEME="Locksmith iOS" SDK=iphonesimulator10.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+
     - DESTINATION="OS=9.0,name=iPad 2" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="OS=9.0,name=iPhone 6" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     - DESTINATION="OS=9.0,name=iPhone 6 Plus" SCHEME="Locksmith iOS" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
@@ -46,11 +53,11 @@ script:
     fi
 
   # Build example in Debug and Release
-  - if [ $BUILD_EXAMPLE == "YES" ]; then 
+  - if [ $BUILD_EXAMPLE == "YES" ]; then
       xcodebuild -workspace Locksmith.xcworkspace -scheme "Locksmith iOS Example" -sdk "$SDK" -destination "$DESTINATION"
         -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
     fi
-  - if [ $BUILD_EXAMPLE == "YES" ]; then 
+  - if [ $BUILD_EXAMPLE == "YES" ]; then
       xcodebuild -workspace Locksmith.xcworkspace -scheme "Locksmith iOS Example" -sdk "$SDK" -destination "$DESTINATION"
         -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
     fi

--- a/Examples/Locksmith iOS Example/Locksmith Extension/InterfaceController.swift
+++ b/Examples/Locksmith iOS Example/Locksmith Extension/InterfaceController.swift
@@ -30,7 +30,7 @@ class InterfaceController: WKInterfaceController, WCSessionDelegate {
             
             var account: String { return username }
             
-            var data: [String: AnyObject] {
+            var data: [String: Any] {
                 return ["password": password]
             }
         }
@@ -50,6 +50,6 @@ class InterfaceController: WKInterfaceController, WCSessionDelegate {
     }
     
     @available(watchOSApplicationExtension 2.2, *)
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: NSError?) {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
     }
 }

--- a/Examples/Locksmith iOS Example/Locksmith iOS Example.xcodeproj/project.pbxproj
+++ b/Examples/Locksmith iOS Example/Locksmith iOS Example.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -446,6 +447,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -544,6 +546,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Locksmith-iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -558,6 +561,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Locksmith-iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Examples/Locksmith iOS Example/Locksmith iOS Example.xcodeproj/project.pbxproj
+++ b/Examples/Locksmith iOS Example/Locksmith iOS Example.xcodeproj/project.pbxproj
@@ -98,6 +98,12 @@
 		379DD1E5C8CDE5ABD6E50A38 /* Pods-watch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watch.release.xcconfig"; path = "Pods/Target Support Files/Pods-watch/Pods-watch.release.xcconfig"; sourceTree = "<group>"; };
 		74E67F961D2CBE4F8D171223 /* Pods-watch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watch.debug.xcconfig"; path = "Pods/Target Support Files/Pods-watch/Pods-watch.debug.xcconfig"; sourceTree = "<group>"; };
 		8D5C601685F38F2EA6AA2CA0 /* Pods-app.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app.release.xcconfig"; path = "Pods/Target Support Files/Pods-app/Pods-app.release.xcconfig"; sourceTree = "<group>"; };
+		E3DD3B201D84354F00A59312 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E3DD3B221D84354F00A59312 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E3DD3B251D84354F00A59312 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E3DD3B271D84354F00A59312 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E3DD3B2A1D84354F00A59312 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E3DD3B2C1D84354F00A59312 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FFB6EBF2507E751B53E55514 /* Pods-app.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app.debug.xcconfig"; path = "Pods/Target Support Files/Pods-app/Pods-app.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -148,6 +154,7 @@
 				0E13A9A21BA3EE8700A06FF9 /* Locksmith iOS Example */,
 				056F2A701BA42E3C00B24B65 /* Locksmith */,
 				056F2A7F1BA42E3C00B24B65 /* Locksmith Extension */,
+				E3DD3B1F1D84354F00A59312 /* Test Host */,
 				0E13A9A11BA3EE8700A06FF9 /* Products */,
 				74B88A8534E794C2027D6B3D /* Pods */,
 				D1E3110F9ED1A0EE737E7A37 /* Frameworks */,
@@ -197,6 +204,19 @@
 				1D62CFE6D2814693AE03CF5C /* Pods_watch.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E3DD3B1F1D84354F00A59312 /* Test Host */ = {
+			isa = PBXGroup;
+			children = (
+				E3DD3B201D84354F00A59312 /* AppDelegate.swift */,
+				E3DD3B221D84354F00A59312 /* ViewController.swift */,
+				E3DD3B241D84354F00A59312 /* Main.storyboard */,
+				E3DD3B271D84354F00A59312 /* Assets.xcassets */,
+				E3DD3B291D84354F00A59312 /* LaunchScreen.storyboard */,
+				E3DD3B2C1D84354F00A59312 /* Info.plist */,
+			);
+			path = "Test Host";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -262,6 +282,7 @@
 		0E13A9981BA3EE8600A06FF9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Matthew Palmer";
 				TargetAttributes = {
@@ -381,6 +402,22 @@
 			isa = PBXVariantGroup;
 			children = (
 				0E13A9AD1BA3EE8700A06FF9 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		E3DD3B241D84354F00A59312 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E3DD3B251D84354F00A59312 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E3DD3B291D84354F00A59312 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E3DD3B2A1D84354F00A59312 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";

--- a/Examples/Locksmith iOS Example/Locksmith iOS Example/AppDelegate.swift
+++ b/Examples/Locksmith iOS Example/Locksmith iOS Example/AppDelegate.swift
@@ -12,8 +12,8 @@ import Locksmith
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         struct TwitterAccount: ReadableSecureStorable, CreateableSecureStorable, DeleteableSecureStorable, GenericPasswordSecureStorable {
             let username: String
             let password: String
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             var account: String { return username }
             
-            var data: [String: AnyObject] {
+            var data: [String: Any] {
                 return ["password": password]
             }
         }

--- a/Examples/Locksmith iOS Example/Test Host/AppDelegate.swift
+++ b/Examples/Locksmith iOS Example/Test Host/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Test Host
+//
+//  Created by Federico Trimboli on 9/10/16.
+//  Copyright © 2016 Matthew Palmer. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Examples/Locksmith iOS Example/Test Host/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Locksmith iOS Example/Test Host/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/Locksmith iOS Example/Test Host/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/Locksmith iOS Example/Test Host/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Locksmith iOS Example/Test Host/Base.lproj/Main.storyboard
+++ b/Examples/Locksmith iOS Example/Test Host/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Locksmith iOS Example/Test Host/Info.plist
+++ b/Examples/Locksmith iOS Example/Test Host/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Locksmith iOS Example/Test Host/ViewController.swift
+++ b/Examples/Locksmith iOS Example/Test Host/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  Test Host
+//
+//  Created by Federico Trimboli on 9/10/16.
+//  Copyright © 2016 Matthew Palmer. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -621,6 +621,7 @@
 				PRODUCT_NAME = Locksmith;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -645,6 +646,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -661,6 +663,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Locksmith-OS-XTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -678,6 +681,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -697,6 +701,7 @@
 				PRODUCT_NAME = Locksmith;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -720,6 +725,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -835,6 +841,7 @@
 				PRODUCT_NAME = Locksmith;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -860,6 +867,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};

--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -953,7 +953,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Test Host/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Test-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -975,7 +975,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Test Host/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Test-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1098,6 +1098,7 @@
 				E3DD3B441D84356600A59312 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		FBD0C9501C1866BE00291F2A /* Build configuration list for PBXNativeTarget "Locksmith tvOS" */ = {
 			isa = XCConfigurationList;

--- a/Locksmith.xcodeproj/project.pbxproj
+++ b/Locksmith.xcodeproj/project.pbxproj
@@ -35,6 +35,11 @@
 		DF6BD4B91BB0524500A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF6BD4BC1BB054CB00A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF6BD4BD1BB054D400A3EB64 /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E3DD3B371D84356600A59312 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DD3B361D84356500A59312 /* AppDelegate.swift */; };
+		E3DD3B391D84356600A59312 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DD3B381D84356600A59312 /* ViewController.swift */; };
+		E3DD3B3C1D84356600A59312 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E3DD3B3A1D84356600A59312 /* Main.storyboard */; };
+		E3DD3B3E1D84356600A59312 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E3DD3B3D1D84356600A59312 /* Assets.xcassets */; };
+		E3DD3B411D84356600A59312 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E3DD3B3F1D84356600A59312 /* LaunchScreen.storyboard */; };
 		FBD0C9511C18693200291F2A /* Dictionary_Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC25C401BA38539004191AF /* Dictionary_Initializers.swift */; };
 		FBD0C9521C18693900291F2A /* Locksmith.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FBD0C9531C18694100291F2A /* Locksmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC25C421BA38539004191AF /* Locksmith.swift */; };
@@ -60,6 +65,13 @@
 			remoteGlobalIDString = 0EC25C741BA385F6004191AF;
 			remoteInfo = "Locksmith OS X";
 		};
+		E3DD3B471D84360300A59312 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFFB19C71A4870A300CCFFC3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E3DD3B331D84356500A59312;
+			remoteInfo = "Test Host";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -79,6 +91,14 @@
 		0EC25C9E1BA389CB004191AF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0EC25CA71BA39C9F004191AF /* Locksmith.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Locksmith.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF6BD4B61BB051ED00A3EB64 /* Locksmith.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Locksmith.h; sourceTree = "<group>"; };
+		E3DD3B341D84356500A59312 /* Test Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Test Host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3DD3B361D84356500A59312 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E3DD3B381D84356600A59312 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E3DD3B3B1D84356600A59312 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E3DD3B3D1D84356600A59312 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E3DD3B401D84356600A59312 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E3DD3B421D84356600A59312 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E3DD3B461D84358100A59312 /* Test Host.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Test Host.entitlements"; sourceTree = "<group>"; };
 		FBD0C9491C1866BE00291F2A /* Locksmith.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Locksmith.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -114,6 +134,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0EC25CA31BA39C9F004191AF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E3DD3B311D84356500A59312 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -176,6 +203,7 @@
 			children = (
 				0EC25C481BA38539004191AF /* Source */,
 				0EC25C4A1BA38539004191AF /* Tests */,
+				E3DD3B351D84356500A59312 /* Test Host */,
 				BFFB19D11A4870A300CCFFC3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -189,8 +217,23 @@
 				0EC25C7E1BA385F6004191AF /* Locksmith OS X Tests.xctest */,
 				0EC25CA71BA39C9F004191AF /* Locksmith.framework */,
 				FBD0C9491C1866BE00291F2A /* Locksmith.framework */,
+				E3DD3B341D84356500A59312 /* Test Host.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		E3DD3B351D84356500A59312 /* Test Host */ = {
+			isa = PBXGroup;
+			children = (
+				E3DD3B461D84358100A59312 /* Test Host.entitlements */,
+				E3DD3B361D84356500A59312 /* AppDelegate.swift */,
+				E3DD3B381D84356600A59312 /* ViewController.swift */,
+				E3DD3B3A1D84356600A59312 /* Main.storyboard */,
+				E3DD3B3D1D84356600A59312 /* Assets.xcassets */,
+				E3DD3B3F1D84356600A59312 /* LaunchScreen.storyboard */,
+				E3DD3B421D84356600A59312 /* Info.plist */,
+			);
+			path = "Test Host";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -261,6 +304,7 @@
 			);
 			dependencies = (
 				0EC25C651BA385AB004191AF /* PBXTargetDependency */,
+				E3DD3B481D84360300A59312 /* PBXTargetDependency */,
 			);
 			name = "Locksmith iOS Tests";
 			productName = "Locksmith iOSTests";
@@ -321,6 +365,23 @@
 			productReference = 0EC25CA71BA39C9F004191AF /* Locksmith.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		E3DD3B331D84356500A59312 /* Test Host */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E3DD3B451D84356600A59312 /* Build configuration list for PBXNativeTarget "Test Host" */;
+			buildPhases = (
+				E3DD3B301D84356500A59312 /* Sources */,
+				E3DD3B311D84356500A59312 /* Frameworks */,
+				E3DD3B321D84356500A59312 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Test Host";
+			productName = "Test Host";
+			productReference = E3DD3B341D84356500A59312 /* Test Host.app */;
+			productType = "com.apple.product-type.application";
+		};
 		FBD0C9481C1866BE00291F2A /* Locksmith tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FBD0C9501C1866BE00291F2A /* Build configuration list for PBXNativeTarget "Locksmith tvOS" */;
@@ -345,7 +406,7 @@
 		BFFB19C71A4870A300CCFFC3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Mathew Palmer";
 				TargetAttributes = {
@@ -356,6 +417,7 @@
 					0EC25C611BA385AB004191AF = {
 						CreatedOnToolsVersion = 7.0;
 						LastSwiftMigration = 0800;
+						TestTargetID = E3DD3B331D84356500A59312;
 					};
 					0EC25C741BA385F6004191AF = {
 						CreatedOnToolsVersion = 7.0;
@@ -365,6 +427,15 @@
 					};
 					0EC25CA61BA39C9F004191AF = {
 						CreatedOnToolsVersion = 7.0;
+					};
+					E3DD3B331D84356500A59312 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 1;
+							};
+						};
 					};
 					FBD0C9481C1866BE00291F2A = {
 						CreatedOnToolsVersion = 7.2;
@@ -377,6 +448,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = BFFB19C61A4870A300CCFFC3;
 			productRefGroup = BFFB19D11A4870A300CCFFC3 /* Products */;
@@ -389,6 +461,7 @@
 				0EC25C7D1BA385F6004191AF /* Locksmith OS X Tests */,
 				0EC25CA61BA39C9F004191AF /* Locksmith watchOS */,
 				FBD0C9481C1866BE00291F2A /* Locksmith tvOS */,
+				E3DD3B331D84356500A59312 /* Test Host */,
 			);
 		};
 /* End PBXProject section */
@@ -426,6 +499,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E3DD3B321D84356500A59312 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E3DD3B411D84356600A59312 /* LaunchScreen.storyboard in Resources */,
+				E3DD3B3E1D84356600A59312 /* Assets.xcassets in Resources */,
+				E3DD3B3C1D84356600A59312 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -497,6 +580,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E3DD3B301D84356500A59312 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E3DD3B391D84356600A59312 /* ViewController.swift in Sources */,
+				E3DD3B371D84356600A59312 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FBD0C9441C1866BE00291F2A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -524,7 +616,31 @@
 			target = 0EC25C741BA385F6004191AF /* Locksmith OS X */;
 			targetProxy = 0EC25C801BA385F6004191AF /* PBXContainerItemProxy */;
 		};
+		E3DD3B481D84360300A59312 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E3DD3B331D84356500A59312 /* Test Host */;
+			targetProxy = E3DD3B471D84360300A59312 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		E3DD3B3A1D84356600A59312 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E3DD3B3B1D84356600A59312 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E3DD3B3F1D84356600A59312 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E3DD3B401D84356600A59312 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		0EC25C6B1BA385AB004191AF /* Debug */ = {
@@ -582,6 +698,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Locksmith-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Test Host.app/Test Host";
 			};
 			name = Debug;
 		};
@@ -598,6 +715,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Test Host.app/Test Host";
 			};
 			name = Release;
 		};
@@ -823,6 +941,49 @@
 			};
 			name = Release;
 		};
+		E3DD3B431D84356600A59312 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Test Host/Test Host.entitlements";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Test Host/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Test-Host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		E3DD3B441D84356600A59312 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Test Host/Test Host.entitlements";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Test Host/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.matthewpalmer.Test-Host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		FBD0C94E1C1866BE00291F2A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -929,6 +1090,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E3DD3B451D84356600A59312 /* Build configuration list for PBXNativeTarget "Test Host" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E3DD3B431D84356600A59312 /* Debug */,
+				E3DD3B441D84356600A59312 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		FBD0C9501C1866BE00291F2A /* Build configuration list for PBXNativeTarget "Locksmith tvOS" */ = {
 			isa = XCConfigurationList;

--- a/Source/Locksmith.swift
+++ b/Source/Locksmith.swift
@@ -518,14 +518,14 @@ extension CreateableSecureStorable {
         let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
 
         if let error = LocksmithError(fromStatusCode: Int(status)) {
-            if error == .NotFound || error == .NotAvailable {
+            if error == .notFound || error == .notAvailable {
                 try self.createInSecureStore()
             } else {
                 throw error
             }
         } else {
             if status != errSecSuccess {
-                throw LocksmithError.Undefined
+                throw LocksmithError.undefined
             }
         }
     }

--- a/Source/Locksmith.swift
+++ b/Source/Locksmith.swift
@@ -450,7 +450,7 @@ public extension ReadableSecureStorable {
 public extension ReadableSecureStorable where Self : GenericPasswordSecureStorable {
     var asReadableSecureStoragePropertyDictionary: [String: Any] {
         var old = genericPasswordBaseStoragePropertyDictionary
-        old[String(kSecReturnData)] = true
+        old[String(kSecReturnData)] = kCFBooleanTrue
         old[String(kSecMatchLimit)] = kSecMatchLimitOne
         old[String(kSecReturnAttributes)] = kCFBooleanTrue
         
@@ -461,7 +461,7 @@ public extension ReadableSecureStorable where Self : GenericPasswordSecureStorab
 public extension ReadableSecureStorable where Self : InternetPasswordSecureStorable {
     var asReadableSecureStoragePropertyDictionary: [String: Any] {
         var old = internetPasswordBaseStoragePropertyDictionary
-        old[String(kSecReturnData)] = true
+        old[String(kSecReturnData)] = kCFBooleanTrue
         old[String(kSecMatchLimit)] = kSecMatchLimitOne
         old[String(kSecReturnAttributes)] = kCFBooleanTrue
         return old

--- a/Source/Locksmith.swift
+++ b/Source/Locksmith.swift
@@ -2,12 +2,12 @@ import Foundation
 
 public let LocksmithDefaultService = Bundle.main.infoDictionary![String(kCFBundleIdentifierKey)] as? String ?? "com.locksmith.defaultService"
 
-public typealias PerformRequestClosureType = (requestReference: CFDictionary, result: inout AnyObject?) -> (OSStatus)
+public typealias PerformRequestClosureType = (_ requestReference: CFDictionary, _ result: inout AnyObject?) -> (OSStatus)
 
 
 // MARK: - Locksmith
 public struct Locksmith {
-    public static func loadDataForUserAccount(userAccount: String, inService service: String = LocksmithDefaultService) -> [String: AnyObject]? {
+    public static func loadDataForUserAccount(userAccount: String, inService service: String = LocksmithDefaultService) -> [String: Any]? {
         struct ReadRequest: GenericPasswordSecureStorable, ReadableSecureStorable {
             let service: String
             let account: String
@@ -17,11 +17,11 @@ public struct Locksmith {
         return request.readFromSecureStore()?.data
     }
     
-    public static func saveData(data: [String: AnyObject], forUserAccount userAccount: String, inService service: String = LocksmithDefaultService) throws {
+    public static func saveData(data: [String: Any], forUserAccount userAccount: String, inService service: String = LocksmithDefaultService) throws {
         struct CreateRequest: GenericPasswordSecureStorable, CreateableSecureStorable {
             let service: String
             let account: String
-            let data: [String: AnyObject]
+            let data: [String: Any]
         }
         
         let request = CreateRequest(service: service, account: userAccount, data: data)
@@ -38,11 +38,11 @@ public struct Locksmith {
         return try request.deleteFromSecureStore()
     }
     
-    public static func updateData(data: [String: AnyObject], forUserAccount userAccount: String, inService service: String = LocksmithDefaultService) throws {
+    public static func updateData(data: [String: Any], forUserAccount userAccount: String, inService service: String = LocksmithDefaultService) throws {
         struct UpdateRequest: GenericPasswordSecureStorable, CreateableSecureStorable {
             let service: String
             let account: String
-            let data: [String: AnyObject]
+            let data: [String: Any]
         }
 
         let request = UpdateRequest(service: service, account: userAccount, data: data)
@@ -61,7 +61,7 @@ public extension SecureStorable {
     var accessible: LocksmithAccessibleOption? { return nil }
     var accessGroup: String? { return nil }
     
-    var secureStorableBaseStoragePropertyDictionary: [String: AnyObject] {
+    var secureStorableBaseStoragePropertyDictionary: [String: Any] {
         let dictionary = [
             String(kSecAttrAccessGroup): accessGroup,
             String(kSecAttrAccessible): accessible?.rawValue
@@ -71,12 +71,12 @@ public extension SecureStorable {
     }
     
     @discardableResult
-    private func performSecureStorageAction(closure: PerformRequestClosureType, secureStoragePropertyDictionary: [String: AnyObject]) throws -> [String: AnyObject]? {
+    fileprivate func performSecureStorageAction(closure: PerformRequestClosureType, secureStoragePropertyDictionary: [String: Any]) throws -> [String: Any]? {
         var result: AnyObject?
         let request = secureStoragePropertyDictionary
         let requestReference = request as CFDictionary
         
-        let status = closure(requestReference: requestReference, result: &result)
+        let status = closure(requestReference, &result)
         
         let statusCode = Int(status)
         
@@ -97,13 +97,13 @@ public extension SecureStorable {
             return nil
         }
         
-        return result as? [String: AnyObject]
+        return result as? [String: Any]
     }
 }
 
 public extension SecureStorable where Self : InternetPasswordSecureStorable {
-    private var internetPasswordBaseStoragePropertyDictionary: [String: AnyObject] {
-        var dictionary = [String: AnyObject]()
+    fileprivate var internetPasswordBaseStoragePropertyDictionary: [String: Any] {
+        var dictionary = [String: Any]()
         
         // add in whatever turns out to be required...
         dictionary[String(kSecAttrServer)] = server
@@ -112,7 +112,7 @@ public extension SecureStorable where Self : InternetPasswordSecureStorable {
         dictionary[String(kSecAttrAuthenticationType)] = authenticationType.rawValue
         dictionary[String(kSecAttrSecurityDomain)] = securityDomain
         dictionary[String(kSecAttrPath)] = path
-        dictionary[String(kSecClass)] = LocksmithSecurityClass.InternetPassword.rawValue
+        dictionary[String(kSecClass)] = LocksmithSecurityClass.internetPassword.rawValue
         
         let toMergeWith = [
             accountSecureStoragePropertyDictionary,
@@ -138,7 +138,7 @@ public protocol AccountBasedSecureStorable {
 }
 
 public extension AccountBasedSecureStorable {
-    private var accountSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var accountSecureStoragePropertyDictionary: [String: Any] {
         return [String(kSecAttrAccount): account]
     }
 }
@@ -159,7 +159,7 @@ public protocol DescribableSecureStorable {
 public extension DescribableSecureStorable {
     var description: String? { return nil }
     
-    private var describableSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var describableSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [
             String(kSecAttrDescription): description
             ])
@@ -182,7 +182,7 @@ public protocol CommentableSecureStorable {
 public extension CommentableSecureStorable {
     var comment: String? { return nil }
     
-    private var commentableSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var commentableSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [
             String(kSecAttrComment): comment
             ])
@@ -205,7 +205,7 @@ public protocol CreatorDesignatableSecureStorable {
 public extension CreatorDesignatableSecureStorable {
     var creator: UInt? { return nil }
     
-    private var creatorDesignatableSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var creatorDesignatableSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [String(kSecAttrCreator): creator])
     }
 }
@@ -226,7 +226,7 @@ public protocol LabellableSecureStorable {
 public extension LabellableSecureStorable {
     var label: String? { return nil }
     
-    private var labellableSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var labellableSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [String(kSecAttrLabel): label])
     }
 }
@@ -247,7 +247,7 @@ public protocol TypeDesignatableSecureStorable {
 public extension TypeDesignatableSecureStorable {
     var type: UInt? { return nil }
     
-    private var typeDesignatableSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var typeDesignatableSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [String(kSecAttrType): type])
     }
 }
@@ -267,7 +267,7 @@ public protocol IsInvisibleAssignableSecureStorable {
 public extension IsInvisibleAssignableSecureStorable {
     var isInvisible: Bool? { return nil }
     
-    private var isInvisibleSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var isInvisibleSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [String(kSecAttrIsInvisible): isInvisible])
     }
 }
@@ -287,7 +287,7 @@ public protocol IsNegativeAssignableSecureStorable {
 public extension IsNegativeAssignableSecureStorable {
     var isNegative: Bool? { return nil }
     
-    private var isNegativeSecureStoragePropertyDictionary: [String: AnyObject] {
+    fileprivate var isNegativeSecureStoragePropertyDictionary: [String: Any] {
         return Dictionary(withoutOptionalValues: [String(kSecAttrIsNegative): isNegative])
     }
 }
@@ -332,12 +332,12 @@ public extension GenericPasswordSecureStorableResultType {
 }
 
 public extension SecureStorable where Self : GenericPasswordSecureStorable {
-    private var genericPasswordBaseStoragePropertyDictionary: [String: AnyObject] {
-        var dictionary = [String: AnyObject?]()
+    fileprivate var genericPasswordBaseStoragePropertyDictionary: [String: Any] {
+        var dictionary = [String: Any?]()
         
         dictionary[String(kSecAttrService)] = service
         dictionary[String(kSecAttrGeneric)] = generic
-        dictionary[String(kSecClass)] = LocksmithSecurityClass.GenericPassword.rawValue
+        dictionary[String(kSecClass)] = LocksmithSecurityClass.genericPassword.rawValue
         
         dictionary = Dictionary(initial: dictionary, toMerge: describableSecureStoragePropertyDictionary)
         
@@ -421,7 +421,7 @@ public protocol KeySecureStorable: SecureStorable {}
 
 /// Conformance to this protocol indicates that your type is able to be created and saved to a secure storage container.
 public protocol CreateableSecureStorable: SecureStorable {
-    var data: [String: AnyObject] { get }
+    var data: [String: Any] { get }
     var performCreateRequestClosure: PerformRequestClosureType { get }
     func createInSecureStore() throws
     func updateInSecureStore() throws
@@ -437,7 +437,7 @@ public protocol ReadableSecureStorable: SecureStorable {
 public extension ReadableSecureStorable {
     var performReadRequestClosure: PerformRequestClosureType {
         return { (requestReference: CFDictionary, result: inout AnyObject?) in
-            return withUnsafeMutablePointer(&result) { SecItemCopyMatching(requestReference, UnsafeMutablePointer($0)) }
+            return withUnsafeMutablePointer(to: &result) { SecItemCopyMatching(requestReference, UnsafeMutablePointer($0)) }
         }
     }
     
@@ -448,7 +448,7 @@ public extension ReadableSecureStorable {
 }
 
 public extension ReadableSecureStorable where Self : GenericPasswordSecureStorable {
-    var asReadableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asReadableSecureStoragePropertyDictionary: [String: Any] {
         var old = genericPasswordBaseStoragePropertyDictionary
         old[String(kSecReturnData)] = true
         old[String(kSecMatchLimit)] = kSecMatchLimitOne
@@ -459,7 +459,7 @@ public extension ReadableSecureStorable where Self : GenericPasswordSecureStorab
 }
 
 public extension ReadableSecureStorable where Self : InternetPasswordSecureStorable {
-    var asReadableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asReadableSecureStoragePropertyDictionary: [String: Any] {
         var old = internetPasswordBaseStoragePropertyDictionary
         old[String(kSecReturnData)] = true
         old[String(kSecMatchLimit)] = kSecMatchLimitOne
@@ -469,7 +469,7 @@ public extension ReadableSecureStorable where Self : InternetPasswordSecureStora
 }
 
 struct GenericPasswordResult: GenericPasswordSecureStorableResultType {
-    var resultDictionary: [String: AnyObject]
+    var resultDictionary: [String: Any]
 }
 
 public extension ReadableSecureStorable where Self : GenericPasswordSecureStorable {
@@ -511,11 +511,11 @@ public protocol DeleteableSecureStorable: SecureStorable {
 // MARK: - Default property dictionaries
 
 extension CreateableSecureStorable {
-    func updateInSecureStore(query: [String: AnyObject]) throws {
+    func updateInSecureStore(query: [String: Any]) throws {
         var attributesToUpdate = query
         attributesToUpdate[String(kSecClass)] = nil
 
-        let status = SecItemUpdate(query, attributesToUpdate)
+        let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
 
         if let error = LocksmithError(fromStatusCode: Int(status)) {
             if error == .NotFound || error == .NotAvailable {
@@ -532,7 +532,7 @@ extension CreateableSecureStorable {
 }
 
 public extension CreateableSecureStorable where Self : GenericPasswordSecureStorable {
-    var asCreateableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asCreateableSecureStoragePropertyDictionary: [String: Any] {
         var old = genericPasswordBaseStoragePropertyDictionary
         old[String(kSecValueData)] = NSKeyedArchiver.archivedData(withRootObject: data)
         return old
@@ -549,7 +549,7 @@ public extension CreateableSecureStorable where Self : GenericPasswordSecureStor
 }
 
 public extension CreateableSecureStorable where Self : InternetPasswordSecureStorable {
-    var asCreateableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asCreateableSecureStoragePropertyDictionary: [String: Any] {
         var old = internetPasswordBaseStoragePropertyDictionary
         old[String(kSecValueData)] = NSKeyedArchiver.archivedData(withRootObject: data)
         return old
@@ -559,7 +559,7 @@ public extension CreateableSecureStorable where Self : InternetPasswordSecureSto
 public extension CreateableSecureStorable {
     var performCreateRequestClosure: PerformRequestClosureType {
         return { (requestReference: CFDictionary, result: inout AnyObject?) in
-            return withUnsafeMutablePointer(&result) { SecItemAdd(requestReference, UnsafeMutablePointer($0)) }
+            return withUnsafeMutablePointer(to: &result) { SecItemAdd(requestReference, UnsafeMutablePointer($0)) }
         }
     }
 }
@@ -582,13 +582,13 @@ public extension DeleteableSecureStorable {
 }
 
 public extension DeleteableSecureStorable where Self : GenericPasswordSecureStorable {
-    var asDeleteableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asDeleteableSecureStoragePropertyDictionary: [String: Any] {
         return genericPasswordBaseStoragePropertyDictionary
     }
 }
 
 public extension DeleteableSecureStorable where Self : InternetPasswordSecureStorable {
-    var asDeleteableSecureStoragePropertyDictionary: [String: AnyObject] {
+    var asDeleteableSecureStoragePropertyDictionary: [String: Any] {
         return internetPasswordBaseStoragePropertyDictionary
     }
 }
@@ -607,24 +607,24 @@ public extension DeleteableSecureStorable where Self : InternetPasswordSecureSto
 
 // MARK: ResultTypes
 public protocol SecureStorableResultType: SecureStorable {
-    var resultDictionary: [String: AnyObject] { get }
-    var data: [String: AnyObject]? { get }
+    var resultDictionary: [String: Any] { get }
+    var data: [String: Any]? { get }
 }
 
 struct InternetPasswordResult: InternetPasswordSecureStorableResultType {
-    var resultDictionary: [String: AnyObject]
+    var resultDictionary: [String: Any]
 }
 
 public extension SecureStorableResultType {
-    var resultDictionary: [String: AnyObject] {
-        return [String: AnyObject]()
+    var resultDictionary: [String: Any] {
+        return [String: Any]()
     }
     
-    var data: [String: AnyObject]? {
+    var data: [String: Any]? {
         guard let aData = resultDictionary[String(kSecValueData)] as? NSData else {
             return nil
         }
         
-        return NSKeyedUnarchiver.unarchiveObject(with: aData as Data) as? [String: AnyObject]
+        return NSKeyedUnarchiver.unarchiveObject(with: aData as Data) as? [String: Any]
     }
 }

--- a/Source/LocksmithAccessibleOption.swift
+++ b/Source/LocksmithAccessibleOption.swift
@@ -2,44 +2,44 @@ import Foundation
 
 // MARK: Accessible
 public enum LocksmithAccessibleOption: RawRepresentable {
-    case WhenUnlocked, AfterFirstUnlock, Always, WhenUnlockedThisDeviceOnly, AfterFirstUnlockThisDeviceOnly, AlwaysThisDeviceOnly, WhenPasscodeSetThisDeviceOnly
+    case whenUnlocked, afterFirstUnlock, always, whenUnlockedThisDeviceOnly, afterFirstUnlockThisDeviceOnly, alwaysThisDeviceOnly, whenPasscodeSetThisDeviceOnly
     
     public init?(rawValue: String) {
         switch rawValue {
         case String(kSecAttrAccessibleWhenUnlocked):
-            self = .WhenUnlocked
+            self = .whenUnlocked
         case String(kSecAttrAccessibleAfterFirstUnlock):
-            self = .AfterFirstUnlock
+            self = .afterFirstUnlock
         case String(kSecAttrAccessibleAlways):
-            self = .Always
+            self = .always
         case String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly):
-            self = .WhenUnlockedThisDeviceOnly
+            self = .whenUnlockedThisDeviceOnly
         case String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly):
-            self = .AfterFirstUnlockThisDeviceOnly
+            self = .afterFirstUnlockThisDeviceOnly
         case String(kSecAttrAccessibleAlwaysThisDeviceOnly):
-            self = .AlwaysThisDeviceOnly
+            self = .alwaysThisDeviceOnly
         case String(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly):
-            self = .WhenPasscodeSetThisDeviceOnly
+            self = .whenPasscodeSetThisDeviceOnly
         default:
-            self = .WhenUnlocked
+            self = .whenUnlocked
         }
     }
     
     public var rawValue: String {
         switch self {
-        case .WhenUnlocked:
+        case .whenUnlocked:
             return String(kSecAttrAccessibleWhenUnlocked)
-        case .AfterFirstUnlock:
+        case .afterFirstUnlock:
             return String(kSecAttrAccessibleAfterFirstUnlock)
-        case .Always:
+        case .always:
             return String(kSecAttrAccessibleAlways)
-        case .WhenPasscodeSetThisDeviceOnly:
+        case .whenPasscodeSetThisDeviceOnly:
             return String(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
-        case .WhenUnlockedThisDeviceOnly:
+        case .whenUnlockedThisDeviceOnly:
             return String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
-        case .AfterFirstUnlockThisDeviceOnly:
+        case .afterFirstUnlockThisDeviceOnly:
             return String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
-        case .AlwaysThisDeviceOnly:
+        case .alwaysThisDeviceOnly:
             return String(kSecAttrAccessibleAlwaysThisDeviceOnly)
         }
     }

--- a/Source/LocksmithError.swift
+++ b/Source/LocksmithError.swift
@@ -2,41 +2,41 @@ import Foundation
 
 // MARK: Locksmith Error
 public enum LocksmithError: String, Error {
-    case Allocate = "Failed to allocate memory."
-    case AuthFailed = "Authorization/Authentication failed."
-    case Decode = "Unable to decode the provided data."
-    case Duplicate = "The item already exists."
-    case InteractionNotAllowed = "Interaction with the Security Server is not allowed."
-    case NoError = "No error."
-    case NotAvailable = "No trust results are available."
-    case NotFound = "The item cannot be found."
-    case Param = "One or more parameters passed to the function were not valid."
-    case RequestNotSet = "The request was not set"
-    case TypeNotFound = "The type was not found"
-    case UnableToClear = "Unable to clear the keychain"
-    case Undefined = "An undefined error occurred"
-    case Unimplemented = "Function or operation not implemented."
+    case allocate = "Failed to allocate memory."
+    case authFailed = "Authorization/Authentication failed."
+    case decode = "Unable to decode the provided data."
+    case duplicate = "The item already exists."
+    case interactionNotAllowed = "Interaction with the Security Server is not allowed."
+    case noError = "No error."
+    case notAvailable = "No trust results are available."
+    case notFound = "The item cannot be found."
+    case param = "One or more parameters passed to the function were not valid."
+    case requestNotSet = "The request was not set"
+    case typeNotFound = "The type was not found"
+    case unableToClear = "Unable to clear the keychain"
+    case undefined = "An undefined error occurred"
+    case unimplemented = "Function or operation not implemented."
     
     init?(fromStatusCode code: Int) {
         switch code {
         case Int(errSecAllocate):
-            self = .Allocate
+            self = .allocate
         case Int(errSecAuthFailed):
-            self = .AuthFailed
+            self = .authFailed
         case Int(errSecDecode):
-            self = .Decode
+            self = .decode
         case Int(errSecDuplicateItem):
-            self = .Duplicate
+            self = .duplicate
         case Int(errSecInteractionNotAllowed):
-            self = .InteractionNotAllowed
+            self = .interactionNotAllowed
         case Int(errSecItemNotFound):
-            self = .NotFound
+            self = .notFound
         case Int(errSecNotAvailable):
-            self = .NotAvailable
+            self = .notAvailable
         case Int(errSecParam):
-            self = .Param
+            self = .param
         case Int(errSecUnimplemented):
-            self = .Unimplemented
+            self = .unimplemented
         default:
             return nil
         }

--- a/Source/LocksmithInternetAuthenticationType.swift
+++ b/Source/LocksmithInternetAuthenticationType.swift
@@ -1,48 +1,48 @@
 import Foundation
 
 public enum LocksmithInternetAuthenticationType: RawRepresentable {
-    case NTLM, MSN, DPA, RPA, HTTPBasic, HTTPDigest, HTMLForm, Default
+    case ntlm, msn, dpa, rpa, httpBasic, httpDigest, htmlForm, `default`
     
     public init?(rawValue: String) {
         switch rawValue {
         case String(kSecAttrAuthenticationTypeNTLM):
-            self = .NTLM
+            self = .ntlm
         case String(kSecAttrAuthenticationTypeMSN):
-            self = .MSN
+            self = .msn
         case String(kSecAttrAuthenticationTypeDPA):
-            self = .DPA
+            self = .dpa
         case String(kSecAttrAuthenticationTypeRPA):
-            self = .RPA
+            self = .rpa
         case String(kSecAttrAuthenticationTypeHTTPBasic):
-            self = .HTTPBasic
+            self = .httpBasic
         case String(kSecAttrAuthenticationTypeHTTPDigest):
-            self = .HTTPDigest
+            self = .httpDigest
         case String(kSecAttrAuthenticationTypeHTMLForm):
-            self = .HTMLForm
+            self = .htmlForm
         case String(kSecAttrAuthenticationTypeDefault):
-            self = .Default
+            self = .default
         default:
-            self = .Default
+            self = .default
         }
     }
     
     public var rawValue: String {
         switch self {
-        case .NTLM:
+        case .ntlm:
             return String(kSecAttrAuthenticationTypeNTLM)
-        case .MSN:
+        case .msn:
             return String(kSecAttrAuthenticationTypeMSN)
-        case .DPA:
+        case .dpa:
             return String(kSecAttrAuthenticationTypeDPA)
-        case .RPA:
+        case .rpa:
             return String(kSecAttrAuthenticationTypeRPA)
-        case .HTTPBasic:
+        case .httpBasic:
             return String(kSecAttrAuthenticationTypeHTTPBasic)
-        case .HTTPDigest:
+        case .httpDigest:
             return String(kSecAttrAuthenticationTypeHTTPDigest)
-        case .HTMLForm:
+        case .htmlForm:
             return String(kSecAttrAuthenticationTypeHTMLForm)
-        case .Default:
+        case .default:
             return String(kSecAttrAuthenticationTypeDefault)
         }
     }

--- a/Source/LocksmithInternetProtocol.swift
+++ b/Source/LocksmithInternetProtocol.swift
@@ -1,140 +1,140 @@
 import Foundation
 
 public enum LocksmithInternetProtocol: RawRepresentable {
-    case FTP, FTPAccount, HTTP, IRC, NNTP, POP3, SMTP, SOCKS, IMAP, LDAP, AppleTalk, AFP, Telnet, SSH, FTPS, HTTPS, HTTPProxy, HTTPSProxy, FTPProxy, SMB, RTSP, RTSPProxy, DAAP, EPPC, IPP, NNTPS, LDAPS, TelnetS, IMAPS, IRCS, POP3S
+    case ftp, ftpAccount, http, irc, nntp, pop3, smtp, socks, imap, ldap, appleTalk, afp, telnet, ssh, ftps, https, httpProxy, httpsProxy, ftpProxy, smb, rtsp, rtspProxy, daap, eppc, ipp, nntps, ldaps, telnetS, imaps, ircs, pop3S
     
     public init?(rawValue: String) {
         switch rawValue {
         case String(kSecAttrProtocolFTP):
-            self = .FTP
+            self = .ftp
         case String(kSecAttrProtocolFTPAccount):
-            self = .FTPAccount
+            self = .ftpAccount
         case String(kSecAttrProtocolHTTP):
-            self = .HTTP
+            self = .http
         case String(kSecAttrProtocolIRC):
-            self = .IRC
+            self = .irc
         case String(kSecAttrProtocolNNTP):
-            self = .NNTP
+            self = .nntp
         case String(kSecAttrProtocolPOP3):
-            self = .POP3
+            self = .pop3
         case String(kSecAttrProtocolSMTP):
-            self = .SMTP
+            self = .smtp
         case String(kSecAttrProtocolSOCKS):
-            self = .SOCKS
+            self = .socks
         case String(kSecAttrProtocolIMAP):
-            self = .IMAP
+            self = .imap
         case String(kSecAttrProtocolLDAP):
-            self = .LDAP
+            self = .ldap
         case String(kSecAttrProtocolAppleTalk):
-            self = .AppleTalk
+            self = .appleTalk
         case String(kSecAttrProtocolAFP):
-            self = .AFP
+            self = .afp
         case String(kSecAttrProtocolTelnet):
-            self = .Telnet
+            self = .telnet
         case String(kSecAttrProtocolSSH):
-            self = .SSH
+            self = .ssh
         case String(kSecAttrProtocolFTPS):
-            self = .FTPS
+            self = .ftps
         case String(kSecAttrProtocolHTTPS):
-            self = .HTTPS
+            self = .https
         case String(kSecAttrProtocolHTTPProxy):
-            self = .HTTPProxy
+            self = .httpProxy
         case String(kSecAttrProtocolHTTPSProxy):
-            self = .HTTPSProxy
+            self = .httpsProxy
         case String(kSecAttrProtocolFTPProxy):
-            self = .FTPProxy
+            self = .ftpProxy
         case String(kSecAttrProtocolSMB):
-            self = .SMB
+            self = .smb
         case String(kSecAttrProtocolRTSP):
-            self = .RTSP
+            self = .rtsp
         case String(kSecAttrProtocolRTSPProxy):
-            self = .RTSPProxy
+            self = .rtspProxy
         case String(kSecAttrProtocolDAAP):
-            self = .DAAP
+            self = .daap
         case String(kSecAttrProtocolEPPC):
-            self = .EPPC
+            self = .eppc
         case String(kSecAttrProtocolIPP):
-            self = .IPP
+            self = .ipp
         case String(kSecAttrProtocolNNTPS):
-            self = .NNTPS
+            self = .nntps
         case String(kSecAttrProtocolLDAPS):
-            self = .LDAPS
+            self = .ldaps
         case String(kSecAttrProtocolTelnetS):
-            self = .TelnetS
+            self = .telnetS
         case String(kSecAttrProtocolIMAPS):
-            self = .IMAPS
+            self = .imaps
         case String(kSecAttrProtocolIRCS):
-            self = .IRCS
+            self = .ircs
         case String(kSecAttrProtocolPOP3S):
-            self = .POP3S
+            self = .pop3S
         default:
-            self = .HTTP
+            self = .http
         }
     }
     
     public var rawValue: String {
         switch self {
-        case .FTP:
+        case .ftp:
             return String(kSecAttrProtocolFTP)
-        case .FTPAccount:
+        case .ftpAccount:
             return String(kSecAttrProtocolFTPAccount)
-        case .HTTP:
+        case .http:
             return String(kSecAttrProtocolHTTP)
-        case .IRC:
+        case .irc:
             return String(kSecAttrProtocolIRC)
-        case .NNTP:
+        case .nntp:
             return String(kSecAttrProtocolNNTP)
-        case .POP3:
+        case .pop3:
             return String(kSecAttrProtocolPOP3)
-        case .SMTP:
+        case .smtp:
             return String(kSecAttrProtocolSMTP)
-        case .SOCKS:
+        case .socks:
             return String(kSecAttrProtocolSOCKS)
-        case .IMAP:
+        case .imap:
             return String(kSecAttrProtocolIMAP)
-        case .LDAP:
+        case .ldap:
             return String(kSecAttrProtocolLDAP)
-        case .AppleTalk:
+        case .appleTalk:
             return String(kSecAttrProtocolAppleTalk)
-        case .AFP:
+        case .afp:
             return String(kSecAttrProtocolAFP)
-        case .Telnet:
+        case .telnet:
             return String(kSecAttrProtocolTelnet)
-        case .SSH:
+        case .ssh:
             return String(kSecAttrProtocolSSH)
-        case .FTPS:
+        case .ftps:
             return String(kSecAttrProtocolFTPS)
-        case .HTTPS:
+        case .https:
             return String(kSecAttrProtocolHTTPS)
-        case .HTTPProxy:
+        case .httpProxy:
             return String(kSecAttrProtocolHTTPProxy)
-        case .HTTPSProxy:
+        case .httpsProxy:
             return String(kSecAttrProtocolHTTPSProxy)
-        case .FTPProxy:
+        case .ftpProxy:
             return String(kSecAttrProtocolFTPProxy)
-        case .SMB:
+        case .smb:
             return String(kSecAttrProtocolSMB)
-        case .RTSP:
+        case .rtsp:
             return String(kSecAttrProtocolRTSP)
-        case .RTSPProxy:
+        case .rtspProxy:
             return String(kSecAttrProtocolRTSPProxy)
-        case .DAAP:
+        case .daap:
             return String(kSecAttrProtocolDAAP)
-        case .EPPC:
+        case .eppc:
             return String(kSecAttrProtocolEPPC)
-        case .IPP:
+        case .ipp:
             return String(kSecAttrProtocolIPP)
-        case .NNTPS:
+        case .nntps:
             return String(kSecAttrProtocolNNTPS)
-        case .LDAPS:
+        case .ldaps:
             return String(kSecAttrProtocolLDAPS)
-        case .TelnetS:
+        case .telnetS:
             return String(kSecAttrProtocolTelnetS)
-        case .IMAPS:
+        case .imaps:
             return String(kSecAttrProtocolIMAPS)
-        case .IRCS:
+        case .ircs:
             return String(kSecAttrProtocolIRCS)
-        case .POP3S:
+        case .pop3S:
             return String(kSecAttrProtocolPOP3S)
         }
     }

--- a/Source/LocksmithSecurityClass.swift
+++ b/Source/LocksmithSecurityClass.swift
@@ -3,36 +3,36 @@ import Foundation
 // With thanks to http://iosdeveloperzone.com/2014/10/22/taming-foundation-constants-into-swift-enums/
 // MARK: Security Class
 public enum LocksmithSecurityClass: RawRepresentable {
-    case GenericPassword, InternetPassword, Certificate, Key, Identity
+    case genericPassword, internetPassword, certificate, key, identity
     
     public init?(rawValue: String) {
         switch rawValue {
         case String(kSecClassGenericPassword):
-            self = .GenericPassword
+            self = .genericPassword
         case String(kSecClassInternetPassword):
-            self = .InternetPassword
+            self = .internetPassword
         case String(kSecClassCertificate):
-            self = .Certificate
+            self = .certificate
         case String(kSecClassKey):
-            self = .Key
+            self = .key
         case String(kSecClassIdentity):
-            self = .Identity
+            self = .identity
         default:
-            self = .GenericPassword
+            self = .genericPassword
         }
     }
     
     public var rawValue: String {
         switch self {
-        case .GenericPassword:
+        case .genericPassword:
             return String(kSecClassGenericPassword)
-        case .InternetPassword:
+        case .internetPassword:
             return String(kSecClassInternetPassword)
-        case .Certificate:
+        case .certificate:
             return String(kSecClassCertificate)
-        case .Key:
+        case .key:
             return String(kSecClassKey)
-        case .Identity:
+        case .identity:
             return String(kSecClassIdentity)
         }
     }

--- a/Test Host/AppDelegate.swift
+++ b/Test Host/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Test Host
+//
+//  Created by Federico Trimboli on 9/10/16.
+//  Copyright © 2016 Locksmith. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Test Host/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Test Host/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Test Host/Base.lproj/LaunchScreen.storyboard
+++ b/Test Host/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Test Host/Base.lproj/Main.storyboard
+++ b/Test Host/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Test Host/Info.plist
+++ b/Test Host/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Test Host/Test Host.entitlements
+++ b/Test Host/Test Host.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)net.matthewpalmer.Test-Host</string>
+	</array>
+</dict>
+</plist>

--- a/Test Host/ViewController.swift
+++ b/Test Host/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  Test Host
+//
+//  Created by Federico Trimboli on 9/10/16.
+//  Copyright © 2016 Locksmith. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/Tests/LocksmithTests.swift
+++ b/Tests/LocksmithTests.swift
@@ -84,9 +84,9 @@ class LocksmithTests: XCTestCase {
         XCTAssertEqual(loaded3, updatedData)
     }
     
-    func createGenericPasswordWithData(_ data: [String: AnyObject]) {
+    func createGenericPasswordWithData(_ data: [String: Any]) {
         struct CreateGenericPassword: CreateableSecureStorable, GenericPasswordSecureStorable {
-            let data: [String: AnyObject]
+            let data: [String: Any]
             let account: String
             let service: String
         }
@@ -104,7 +104,7 @@ class LocksmithTests: XCTestCase {
         let data = ["some": "data"]
         
         struct CreateGenericPassword: CreateableSecureStorable, GenericPasswordSecureStorable, ReadableSecureStorable {
-            var data: [String: AnyObject]
+            var data: [String: Any]
             let account: String
             let service: String
         }
@@ -120,7 +120,7 @@ class LocksmithTests: XCTestCase {
         let data = ["some": "data"]
         
         struct CreateGenericPassword: CreateableSecureStorable, GenericPasswordSecureStorable, ReadableSecureStorable {
-            var data: [String: AnyObject]
+            var data: [String: Any]
             let account: String
             let service: String
         }
@@ -169,7 +169,7 @@ class LocksmithTests: XCTestCase {
         struct Omnivore: ReadableSecureStorable, CreateableSecureStorable, DeleteableSecureStorable, GenericPasswordSecureStorable {
             let account: String
             let service: String
-            let data: [String: AnyObject]
+            let data: [String: Any]
         }
         
         let data: [String: String] = ["something": "else"]
@@ -199,7 +199,7 @@ class LocksmithTests: XCTestCase {
         struct Create : CreateableSecureStorable, InternetPasswordSecureStorable {
             let account: String
             let server: String
-            let data: [String: AnyObject]
+            let data: [String: Any]
             let port: Int
             let internetProtocol: LocksmithInternetProtocol
             let authenticationType: LocksmithInternetAuthenticationType
@@ -208,8 +208,8 @@ class LocksmithTests: XCTestCase {
         let server = "server"
         let initialData = ["one": "two"]
         let port = 8080
-        let internetProtocol = LocksmithInternetProtocol.HTTPS
-        let authenticationType = LocksmithInternetAuthenticationType.DPA
+        let internetProtocol = LocksmithInternetProtocol.https
+        let authenticationType = LocksmithInternetAuthenticationType.dpa
         
         struct Delete: DeleteableSecureStorable, InternetPasswordSecureStorable {
             let account: String
@@ -247,7 +247,7 @@ class LocksmithTests: XCTestCase {
             let comment: String?
             let description: String?
             let creator: UInt?
-            let data: [String: AnyObject]
+            let data: [String: Any]
         }
         
         let initialData = ["one": "two"]
@@ -279,7 +279,7 @@ class LocksmithTests: XCTestCase {
     func testInternetPasswordMetaAttributesAreCreatedAndReturned() {
         struct CreateInternetPassword: CreateableSecureStorable, InternetPasswordSecureStorable {
             let account: String
-            var data: [String: AnyObject]
+            var data: [String: Any]
             let server: String
             let port: Int
             let internetProtocol: LocksmithInternetProtocol
@@ -292,8 +292,8 @@ class LocksmithTests: XCTestCase {
         let initialData = ["internet": "data"]
         let server = "net.matthewpalmer"
         let port = 8080
-        let internetProtocol = LocksmithInternetProtocol.FTP
-        let authenticationType = LocksmithInternetAuthenticationType.HTTPBasic
+        let internetProtocol = LocksmithInternetProtocol.ftp
+        let authenticationType = LocksmithInternetAuthenticationType.httpBasic
         let path = "somePath"
         let securityDomain = "someDomain"
         
@@ -343,7 +343,7 @@ class LocksmithTests: XCTestCase {
         struct CreateInternetPassword: CreateableSecureStorable, InternetPasswordSecureStorable, DeleteableSecureStorable {
             let account: String
             let service: String
-            let data: [String: AnyObject]
+            let data: [String: Any]
             let server: String
             let port: Int
             let internetProtocol: LocksmithInternetProtocol
@@ -355,14 +355,14 @@ class LocksmithTests: XCTestCase {
         
         let account = "myUser"
         let port = 8080
-        let internetProtocol = LocksmithInternetProtocol.HTTP
-        let authenticationType = LocksmithInternetAuthenticationType.HTTPBasic
+        let internetProtocol = LocksmithInternetProtocol.http
+        let authenticationType = LocksmithInternetAuthenticationType.httpBasic
         let path = "some_path"
         let securityDomain = "secdomain"
         let data = ["some": "data"]
         let server = "server"
         
-        let expect = expectation(withDescription: "Must enter the closure")
+        let expect = expectation(description: "Must enter the closure")
         
         let performRequestClosure: PerformRequestClosureType = { (requestReference, result) in
             let dict = requestReference as NSDictionary
@@ -389,12 +389,12 @@ class LocksmithTests: XCTestCase {
         do { try create.deleteFromSecureStore() } catch {}
         try! create.createInSecureStore()
         
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
     }
     
     func testGenericPasswordOptionalAttributesAreAppliedForConformingTypes() {
         struct CreateGenericPassword: CreateableSecureStorable, GenericPasswordSecureStorable {
-            let data: [String: AnyObject]
+            let data: [String: Any]
             let account: String
             let service: String
             let accessGroup: String?
@@ -409,20 +409,20 @@ class LocksmithTests: XCTestCase {
             let generic: Data?
         }
         
-        let data: [String: AnyObject] = ["some": "data"]
+        let data: [String: Any] = ["some": "data"]
         let account: String = "myUser"
         let service: String = "myService"
         let accessGroup: String = "myAccessGroup"
         let description: String = "myDescription"
         let creator: UInt = 5
-        let accessible: LocksmithAccessibleOption = LocksmithAccessibleOption.Always
+        let accessible: LocksmithAccessibleOption = LocksmithAccessibleOption.always
         let comment: String = "myComment"
         let type: UInt = 10
         let isInvisible: Bool = false
         let isNegative: Bool = false
         let generic: Data = Data()
         
-        let expect = expectation(withDescription: "Must enter the closure")
+        let expect = expectation(description: "Must enter the closure")
         
         let performRequestClosure: PerformRequestClosureType = { (requestReference, result) in
             let dict = requestReference as NSDictionary
@@ -461,6 +461,6 @@ class LocksmithTests: XCTestCase {
         
         try! create.createInSecureStore()
 
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
     }
 }


### PR DESCRIPTION
Forked from @pascalfribi's PR https://github.com/matthewpalmer/Locksmith/pull/140. 
Added a Test Host target with Keychain Sharing capabilities.

Also, added @aaronpearce's suggestion to change `old[String(kSecReturnData)] = true` to `old[String(kSecReturnData)] = kCFBooleanTrue` in `asReadableSecureStoragePropertyDictionary`.

Tests are passing in my machine, running Xcode 8 GM.